### PR TITLE
Downgrade @types/node to match vscode electron node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -484,9 +484,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+      "version": "12.12.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.39.tgz",
+      "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg==",
       "dev": true
     },
     "@types/semver": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@types/glob": "^7.1.1",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^13.11.0",
+    "@types/node": "^12.12.39",
     "@types/sinon": "^9.0.0",
     "@types/vscode": "^1.45.0",
     "@typescript-eslint/eslint-plugin": "^2.33.0",


### PR DESCRIPTION
Refs https://github.com/badsyntax/vscode-spotless-gradle/pull/21