### PR TITLE
Add DependencyChecker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,13 @@
       "integrity": "sha512-JKV3f5Bv2TZxK6eJSB9EarsZrnLxrvcFNwI9goq0YRXa3S6NNoCSnI3cG3lkXVIJ03Wng1WXe76kc2JQtRe7AQ==",
       "requires": {
         "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "@sinonjs/commons": {
@@ -121,6 +128,14 @@
             "semver": "^6.0.0",
             "source-map-support": "^0.5.11",
             "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
           }
         },
         "object-hash": {
@@ -1508,6 +1523,12 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
           "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -3687,9 +3708,9 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -3885,6 +3906,12 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -3913,6 +3940,14 @@
         "snyk-nodejs-lockfile-parser": "1.22.0",
         "tar-stream": "^2.1.0",
         "tslib": "^1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "snyk-go-parser": {
@@ -4204,6 +4239,12 @@
           "integrity": "sha512-pF4HjZGSog75kGq7B1InK/wt/N08BuPATo+7HRfv7gZUzccebwv/fmWVGs/j6LvSiLWpCuGGhql51M/wcQsNzA==",
           "dev": true
         },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
         "snyk-module": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/snyk-module/-/snyk-module-2.1.0.tgz",
@@ -4321,6 +4362,12 @@
         "tslib": "^1.10.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
         "tmp": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "richardwillis.vscode-gradle"
   ],
   "extensionDependenciesCompatibility": {
-    "richardwillis.vscode-gradle": "^0.0.1"
+    "richardwillis.vscode-gradle": "^2.7.11"
   },
   "categories": [
     "Formatters"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "extensionDependencies": [
     "richardwillis.vscode-gradle"
   ],
+  "extensionDependenciesCompatibility": {
+    "richardwillis.vscode-gradle": "^0.0.1"
+  },
   "categories": [
     "Formatters"
   ],
@@ -74,6 +77,7 @@
     "vscode-test": "^1.3.0"
   },
   "dependencies": {
+    "semver": "^7.3.2",
     "vscode-gradle": "^2.7.11"
   },
   "snyk": true

--- a/src/DependencyChecker.ts
+++ b/src/DependencyChecker.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import * as semver from 'semver';
 import { INSTALL_COMPATIBLE_EXTENSION_VERSIONS } from './constants';
 
-interface PackageJson {
+export interface PackageJson {
   extensionDependencies: string[];
   extensionDependenciesCompatibility?: {
     [key: string]: string;
@@ -11,7 +11,7 @@ interface PackageJson {
   [key: string]: any;
 }
 
-interface ExtensionVersion {
+export interface ExtensionVersion {
   id: string;
   required: string;
   compatible: boolean;
@@ -60,13 +60,14 @@ export class DependencyChecker {
     } = this.packageJson;
     return extensions.map((extensionDependency) => {
       const extensionVersion = extensionDependency.packageJSON.version;
-      const requiredVersion = compatibleVersions![
-        extensionDependency.packageJSON.id
-      ];
+      const requiredVersion = compatibleVersions![extensionDependency.id];
       const version: ExtensionVersion = {
         id: extensionDependency.id,
         required: requiredVersion,
-        compatible: semver.satisfies(extensionVersion, requiredVersion),
+        compatible: semver.satisfies(
+          extensionVersion,
+          semver.validRange(requiredVersion)
+        ),
       };
       return version;
     });

--- a/src/DependencyChecker.ts
+++ b/src/DependencyChecker.ts
@@ -88,8 +88,6 @@ export class DependencyChecker {
         (extension) => extension.id
       );
       // From here it's up to the user to choose the correct dependency
-      // TODO: Can/should we automate this? (EG if user has auto-updates switched on, then
-      // the version will be reverted).
       await vscode.commands.executeCommand(
         'workbench.extensions.action.showExtensionsWithIds',
         extensionIds

--- a/src/DependencyChecker.ts
+++ b/src/DependencyChecker.ts
@@ -34,7 +34,7 @@ export class DependencyChecker {
     );
 
     if (incompatibleExtensions.length) {
-      await this.notify(incompatibleExtensions);
+      this.notify(incompatibleExtensions);
       return false;
     }
 

--- a/src/DependencyChecker.ts
+++ b/src/DependencyChecker.ts
@@ -1,0 +1,98 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as vscode from 'vscode';
+import * as semver from 'semver';
+import { INSTALL_COMPATIBLE_EXTENSION_VERSIONS } from './constants';
+
+interface PackageJson {
+  extensionDependencies: string[];
+  extensionDependenciesCompatibility?: {
+    [key: string]: string;
+  };
+  [key: string]: any;
+}
+
+interface ExtensionVersion {
+  id: string;
+  required: string;
+  compatible: boolean;
+}
+
+export class DependencyChecker {
+  constructor(private readonly packageJson: PackageJson) {
+    if (!packageJson.extensionDependenciesCompatibility) {
+      throw new Error(
+        `'extensionDependenciesCompatibility' not specified in packageJson`
+      );
+    }
+  }
+
+  public async check(): Promise<boolean> {
+    const extensions = this.getExtensionDependencies();
+    const extensionVersions = this.getExtensionVersions(extensions);
+    const incompatibleExtensions = extensionVersions.filter(
+      (extensionVersion) => !extensionVersion.compatible
+    );
+
+    if (incompatibleExtensions.length) {
+      await this.notify(incompatibleExtensions);
+      return false;
+    }
+
+    return true;
+  }
+
+  private getExtensionDependencies(): vscode.Extension<any>[] {
+    return this.packageJson.extensionDependencies
+      .map((extensionDependency) =>
+        vscode.extensions.getExtension(extensionDependency)
+      )
+      .filter(
+        (extensionDependency) =>
+          extensionDependency && extensionDependency.isActive
+      ) as vscode.Extension<any>[];
+  }
+
+  private getExtensionVersions(
+    extensions: vscode.Extension<any>[]
+  ): ExtensionVersion[] {
+    const {
+      extensionDependenciesCompatibility: compatibleVersions,
+    } = this.packageJson;
+    return extensions.map((extensionDependency) => {
+      const extensionVersion = extensionDependency.packageJSON.version;
+      const requiredVersion = compatibleVersions![
+        extensionDependency.packageJSON.id
+      ];
+      const version: ExtensionVersion = {
+        id: extensionDependency.id,
+        required: requiredVersion,
+        compatible: semver.satisfies(extensionVersion, requiredVersion),
+      };
+      return version;
+    });
+  }
+
+  private async notify(
+    incompatibleExtensions: ExtensionVersion[]
+  ): Promise<void> {
+    const requiredVersions = incompatibleExtensions
+      .map((extension) => `${extension.id}@${extension.required}`)
+      .join(', ');
+    const input = await vscode.window.showErrorMessage(
+      `Extension versions are incompatible: ${requiredVersions}`,
+      INSTALL_COMPATIBLE_EXTENSION_VERSIONS
+    );
+    if (input === INSTALL_COMPATIBLE_EXTENSION_VERSIONS) {
+      const extensionIds = incompatibleExtensions.map(
+        (extension) => extension.id
+      );
+      // From here it's up to the user to choose the correct dependency
+      // TODO: Can/should we automate this? (EG if user has auto-updates switched on, then
+      // the version will be reverted).
+      await vscode.commands.executeCommand(
+        'workbench.extensions.action.showExtensionsWithIds',
+        extensionIds
+      );
+    }
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,3 +31,6 @@ export const SPOTLESS_STATUSES = [
   SPOTLESS_STATUS_IS_CLEAN,
   SPOTLESS_STATUS_IS_DIRTY,
 ];
+
+export const INSTALL_COMPATIBLE_EXTENSION_VERSIONS =
+  'Install compatible versions';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,6 @@ export async function activate(
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const packageJson = require(path.join(context.extensionPath, 'package.json'));
 
-  // Wait for correct extension dependency versions to be installed
   const dependencyChecker = new DependencyChecker(packageJson);
   if (!(await dependencyChecker.check())) {
     return;
@@ -31,8 +30,13 @@ export async function activate(
   const gradleTasksExtension = vscode.extensions.getExtension(
     GRADLE_TASKS_EXTENSION_ID
   );
+  // vscode should be checking this for us (via `extensionDependencies`), but
+  // we're also doing this as a type-check.
+  if (!gradleTasksExtension || !gradleTasksExtension.isActive) {
+    throw new Error('Gradle Tasks extension is not active');
+  }
 
-  const gradleApi = gradleTasksExtension!.exports as GradleApi;
+  const gradleApi = gradleTasksExtension.exports as GradleApi;
   const spotless = new Spotless(gradleApi);
   const fixAllCodeActionProvider = new FixAllCodeActionProvider(spotless);
   const documentFormattingEditProvider = new DocumentFormattingEditProvider(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,9 @@ export async function activate(
 
   // Wait for correct extension dependency versions to be installed
   const dependencyChecker = new DependencyChecker(packageJson);
-  await dependencyChecker.check();
+  if (!(await dependencyChecker.check())) {
+    return;
+  }
 
   const gradleTasksExtension = vscode.extensions.getExtension(
     GRADLE_TASKS_EXTENSION_ID


### PR DESCRIPTION
Fixes https://github.com/badsyntax/vscode-spotless-gradle/issues/18

This will show an error message if the versions don't match. It's at least a little better than silently failing when the upstream API changes. 

<img width="541" alt="Screenshot 2020-05-13 at 13 02 44" src="https://user-images.githubusercontent.com/102141/81820069-05fe3e00-9528-11ea-932c-5f2f380aa820.png">


TODO:

- [x] Tests