### PR TITLE
Use new vscode-gradle API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8079,9 +8079,9 @@
       }
     },
     "vscode-gradle": {
-      "version": "2.7.12",
-      "resolved": "https://registry.npmjs.org/vscode-gradle/-/vscode-gradle-2.7.12.tgz",
-      "integrity": "sha512-00ZL/4XyxZG9uT2brburlvefnsn/qfWhbIlszNzzz9EQz1jEg7I4T9mH5V5kwtzOp6UmGe6f1feJoTXxbM9uGQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-gradle/-/vscode-gradle-3.0.1.tgz",
+      "integrity": "sha512-uteeQ8GQe+VAZ6b8WzQtUIMuh+Bl9RnASSeSfhMhx6tuhEa7xtIGgTqPk78I3F4+u1GUIOIu4ODqL5m/YhkQ0A==",
       "requires": {
         "@grpc/grpc-js": "^1.0.3",
         "@types/google-protobuf": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "richardwillis.vscode-gradle"
   ],
   "extensionDependenciesCompatibility": {
-    "richardwillis.vscode-gradle": "^2.7.11"
+    "richardwillis.vscode-gradle": "^3.0.1"
   },
   "categories": [
     "Formatters"
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "semver": "^7.3.2",
-    "vscode-gradle": "^2.7.12"
+    "vscode-gradle": "^3.0.1"
   },
   "snyk": true
 }

--- a/src/DependencyChecker.ts
+++ b/src/DependencyChecker.ts
@@ -29,7 +29,7 @@ export class DependencyChecker {
     }
   }
 
-  public async check(): Promise<boolean> {
+  public check(): boolean {
     const extensions = this.getExtensionDependencies();
     const extensionVersions = this.getExtensionVersions(extensions);
     const incompatibleExtensions = extensionVersions.filter(

--- a/src/Spotless.ts
+++ b/src/Spotless.ts
@@ -88,11 +88,11 @@ export class Spotless {
       onOutput: (output: Output) => {
         switch (output.getOutputType()) {
           case Output.OutputType.STDOUT:
-            stdOut = output.getMessage();
+            stdOut = output.getOutputString();
             stdOutDeferred.resolve();
             break;
           case Output.OutputType.STDERR:
-            stdErr = output.getMessage().trim();
+            stdErr = output.getOutputString().trim();
             stdErrDeferred.resolve();
             break;
         }

--- a/src/Spotless.ts
+++ b/src/Spotless.ts
@@ -81,7 +81,6 @@ export class Spotless {
         '-PspotlessIdeHookUseStdOut',
         '--quiet',
       ],
-      showProgress: true,
       input: document.getText(),
       showOutputColors: false,
       outputStream,
@@ -118,7 +117,7 @@ export class Spotless {
         return stdOut;
       }
       if (stdErr !== SPOTLESS_STATUS_IS_CLEAN) {
-        throw new Error(stdErr);
+        throw new Error(stdErr || 'No status received from Spotless');
       }
     }
     return null;


### PR DESCRIPTION
In preparation for a new version of vscode-gradle with a new API being released.

Tests will be broken until I upgrade the vscode-gradle package.