### PR TITLE
Simplify streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Supports `java`, `kotlin`, `kotlinscript`, `scala`, `sql`, `groovy`, `javascript
 
 ## Requirements
 
+- [VS Code >= 1.45.0](https://code.visualstudio.com/download)
 - [Gradle Tasks](https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-gradle)
 - [Spotless Gradle Plugin >= 3.30.0](https://github.com/diffplug/spotless/tree/master/plugin-gradle)
 - [Java >= 8](https://adoptopenjdk.net/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8069,9 +8069,9 @@
       }
     },
     "vscode-gradle": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-gradle/-/vscode-gradle-3.0.1.tgz",
-      "integrity": "sha512-uteeQ8GQe+VAZ6b8WzQtUIMuh+Bl9RnASSeSfhMhx6tuhEa7xtIGgTqPk78I3F4+u1GUIOIu4ODqL5m/YhkQ0A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-gradle/-/vscode-gradle-3.0.2.tgz",
+      "integrity": "sha512-QCnVpjM4vOI7hfvnqhL9lOVh0+JS5iwu6tzSylZ/JHCCBHHZVh5FZFVF/jkKJd84V6vzp/xeHU4UuizKQW22Mw==",
       "requires": {
         "@grpc/grpc-js": "^1.0.3",
         "@types/google-protobuf": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "semver": "^7.3.2",
-    "vscode-gradle": "^3.0.1"
+    "vscode-gradle": "^3.0.2"
   },
   "snyk": true
 }

--- a/src/DependencyChecker.ts
+++ b/src/DependencyChecker.ts
@@ -67,10 +67,12 @@ export class DependencyChecker {
       const version: ExtensionVersion = {
         id: extensionDependency.id,
         required: requiredVersion,
-        compatible: semver.satisfies(
-          extensionVersion,
-          semver.validRange(requiredVersion)
-        ),
+        compatible:
+          extensionVersion === '0.0.0' ||
+          semver.satisfies(
+            extensionVersion,
+            semver.validRange(requiredVersion)
+          ),
       };
       return version;
     });


### PR DESCRIPTION
I've simplified the stream handling in vscode-gradle.
This approach doesn't appear to have any obvious performance issues. I can still run spotless on MassiveFile.java and the bottleneck is Java and not the stream decoding in the client.