### PR TITLE
Don't update VS Code when tests are running

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -450,6 +450,15 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.0.tgz",
+      "integrity": "sha512-xCbDUSZArlmMjiJdczt8AFNH2MwcMb/pj/HKja1hx3u1qzOUINcJktQMGoGVlgFnzxnuCahxKFlcRBkSAcm33g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -1096,6 +1105,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {
@@ -3095,6 +3110,18 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -4133,6 +4160,16 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
       }
     },
     "jszip": {
@@ -7863,6 +7900,12 @@
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "publish": "vsce publish"
   },
   "devDependencies": {
+    "@types/fs-extra": "^9.0.0",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12.12.39",
@@ -71,6 +72,7 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
+    "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
     "mocha": "^7.1.1",
     "prettier": "^2.0.5",

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,5 +1,7 @@
 import * as path from 'path';
 import * as cp from 'child_process';
+import * as fs from 'fs-extra';
+import * as os from 'os';
 
 import {
   runTests,
@@ -10,10 +12,19 @@ import {
 const VSCODE_VERSION = '1.45.0';
 
 async function main(): Promise<void> {
-  try {
-    const extensionDevelopmentPath = path.resolve(__dirname, '../..');
-    const extensionTestsPath = path.resolve(__dirname, './suite/index');
+  const extensionDevelopmentPath = path.resolve(__dirname, '../..');
+  const extensionTestsPath = path.resolve(__dirname, './suite/index');
+  const fixturePath = path.resolve(
+    __dirname,
+    '../../test-fixtures/gradle-project/'
+  );
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-user'));
+  fs.copySync(
+    path.resolve(__dirname, '../../test-fixtures/vscode-user/User'),
+    path.join(tmpDir, 'User')
+  );
 
+  try {
     const vscodeExecutablePath = await downloadAndUnzipVSCode(VSCODE_VERSION);
     const cliPath = resolveCliPathFromVSCodeExecutablePath(
       vscodeExecutablePath
@@ -33,7 +44,7 @@ async function main(): Promise<void> {
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: [
-        path.resolve(__dirname, '../../test-fixtures/gradle-project/'),
+        fixturePath,
         '--disable-extension=vscjava.vscode-java-pack',
         '--disable-extension=redhat.java',
         '--disable-extension=vscjava.vscode-java-dependency',
@@ -42,11 +53,14 @@ async function main(): Promise<void> {
         '--disable-extension=eamodio.gitlens',
         '--disable-extension=sonarsource.sonarlint-vscode',
         '--disable-extension=esbenp.prettier-vscode',
+        `--user-data-dir=${tmpDir}`,
       ],
     });
   } catch (err) {
     console.error('Failed to run tests', err.message);
     process.exit(1);
+  } finally {
+    fs.removeSync(tmpDir);
   }
 }
 

--- a/test-fixtures/gradle-project/.vscode/settings.json
+++ b/test-fixtures/gradle-project/.vscode/settings.json
@@ -4,6 +4,7 @@
     "source.fixAll.spotlessGradle": true,
   },
   "java.format.enabled": false,
+  "update.mode": "none",
   "[java]": {
     "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle"
   },

--- a/test-fixtures/gradle-project/.vscode/settings.json
+++ b/test-fixtures/gradle-project/.vscode/settings.json
@@ -4,7 +4,6 @@
     "source.fixAll.spotlessGradle": true,
   },
   "java.format.enabled": false,
-  "update.mode": "none",
   "[java]": {
     "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle"
   },

--- a/test-fixtures/vscode-user/User/settings.json
+++ b/test-fixtures/vscode-user/User/settings.json
@@ -1,0 +1,3 @@
+{
+  "update.mode": "none"
+}


### PR DESCRIPTION
This has caused issues in the tests in vscode-gradle and is a good change regardless. We don't want extra processes running when the tests are running.