### PR TITLE
Disable formatting & diagnostics by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,10 @@ Before using this extension, ensure you've [configured Spotless](https://github.
 
 ### Enabling Spotless
 
-Spotless formatting & diagnostics are enabled by default. Change the settings to adjust this behaviour:
+Spotless formatting & diagnostics are _disabled by default_. Change the settings to adjust this behaviour:
 
 ```json
 {
-  "spotlessGradle.format.enable": false,
-  "spotlessGradle.diagnostics.enable": false,
   "[java]": {
     "spotlessGradle.format.enable": true,
     "spotlessGradle.diagnostics.enable": true

--- a/package.json
+++ b/package.json
@@ -67,13 +67,13 @@
       "properties": {
         "spotlessGradle.format.enable": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "scope": "language-overridable",
           "description": "Enable/disable formatting"
         },
         "spotlessGradle.diagnostics.enable": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "scope": "language-overridable",
           "description": "Enable/disable diagnostics"
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ export function getConfigFormatEnable(
 ): boolean {
   return vscode.workspace
     .getConfiguration(CONFIG_NAMESPACE, workspaceFolder.uri)
-    .get<boolean>(CONFIG_FORMAT_ENABLE, true);
+    .get<boolean>(CONFIG_FORMAT_ENABLE, false);
 }
 
 export function getConfigLangOverrideFormatEnable(
@@ -30,7 +30,7 @@ export function getConfigDiagnosticsEnable(
 ): boolean {
   return vscode.workspace
     .getConfiguration(CONFIG_NAMESPACE, workspaceFolder.uri)
-    .get<boolean>(CONFIG_DIAGNOSTICS_ENABLE, true);
+    .get<boolean>(CONFIG_DIAGNOSTICS_ENABLE, false);
 }
 
 export function getConfigLangOverrideDiagnosticsEnable(


### PR DESCRIPTION
This is to alleviate the pain caused by https://github.com/badsyntax/vscode-spotless-gradle/issues/173