### PR TITLE
Add Gradle file support & format build file

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const ALL_SUPPORTED_LANGUAGES = [
   'scala',
   'sql',
   'groovy',
+  'gradle',
   'javascript',
   'javascriptreact',
   'typescript',

--- a/test-fixtures/gradle-project/.vscode/settings.json
+++ b/test-fixtures/gradle-project/.vscode/settings.json
@@ -27,6 +27,10 @@
     "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle",
     "spotlessGradle.diagnostics.enable": true
   },
+  "[gradle]": {
+    "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle",
+    "spotlessGradle.diagnostics.enable": true
+  },
   "[javascript]": {
     "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle"
   },
@@ -75,5 +79,6 @@
   },
   "[objective-cpp]": {
     "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle"
-  }
+  },
+  "java.configuration.updateBuildConfiguration": "automatic"
 }

--- a/test-fixtures/gradle-project/build.gradle
+++ b/test-fixtures/gradle-project/build.gradle
@@ -1,39 +1,44 @@
 plugins {
-    id 'java'
-    id 'application'
-    id 'groovy'
-    id 'com.diffplug.spotless' version '6.2.0'
+	id 'java'
+	id 'application'
+	id 'groovy'
+	id 'com.diffplug.spotless' version '6.2.0'
 }
 
 repositories {
-    jcenter()
+	jcenter()
+	mavenCentral()
 }
 
 dependencies {
-  implementation 'org.codehaus.groovy:groovy-all:3.0.9'
+	implementation 'org.codehaus.groovy:groovy-all:3.0.9'
 }
 
 application {
-    mainClassName = 'gradle.project.App'
+	mainClassName = 'gradle.project.App'
 }
 
-jar { 
-  duplicatesStrategy(DuplicatesStrategy.EXCLUDE) 
+jar {
+	duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 }
 
 spotless {
-  java {
-    googleJavaFormat()
-    removeUnusedImports()
-    trimTrailingWhitespace()
-    targetExclude "build/**"
-  }
-  groovy {
-    excludeJava()
-    greclipse()
-  }
-  typescript {
-    target 'src/**/*.ts'
-    prettier()
-  }
+	java {
+		googleJavaFormat()
+		removeUnusedImports()
+		trimTrailingWhitespace()
+		targetExclude "build/**"
+	}
+	groovy {
+		excludeJava()
+		greclipse()
+	}
+	groovyGradle {
+		target '*.gradle'
+		greclipse()
+	}
+	typescript {
+		target 'src/**/*.ts'
+		prettier()
+	}
 }


### PR DESCRIPTION
Refs https://github.com/badsyntax/vscode-spotless-gradle/issues/185

To enable Gradle file support in spotless:

```groovy
apply plugin: 'groovy'
spotless {
  groovyGradle {
    target '*.gradle' // default target of groovyGradle
    greclipse()
  }
}
```

To enable in vs code, add to `settings.json`:

```json
"[gradle]": {
  "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle",
  "spotlessGradle.diagnostics.enable": true,
  "spotlessGradle.format.enable": true
}
```