### PR TITLE
Add support to configure to use gradle configuration cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-spotless-gradle",
-  "version": "0.0.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-spotless-gradle",
-      "version": "0.0.0",
+      "version": "1.3.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-spotless-gradle",
   "displayName": "Spotless Gradle",
   "description": "Format your source files using Spotless via Gradle",
-  "version": "0.0.0",
+  "version": "1.3.1",
   "private": true,
   "publisher": "richardwillis",
   "readme": "README.md",
@@ -223,5 +223,5 @@
     "semver": "^7.3.5",
     "vscode-gradle": "^3.10.1"
   },
-  "snyk": true
+  "snyk": false
 }

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "test": "node ./out/test/runTests.js",
     "install:ext": "code --install-extension vscode-spotless-gradle-0.0.0.vsix --force",
     "preinstall:ext": "npm run package",
-    "snyk-protect": "snyk protect",
+    "snyk-protect": "",
     "prepare": "npm run snyk-protect",
     "compile:dev": "webpack --mode development",
     "compile:prod": "webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,96 @@
           "description": "Enable/disable diagnostics"
         }
       }
-    }
+    },
+    "languages": [
+      {
+        "id": "java",
+        "extensions": [
+          ".java"
+        ]
+      },
+      {
+        "id": "groovy",
+        "extensions": [
+          ".groovy",
+          ".gvy",
+          ".gy",
+          ".gsh"
+        ]
+      },
+      {
+        "id": "kotlin",
+        "extensions": [
+          ".kt"
+        ]
+      },
+      {
+        "id": "cpp",
+        "extensions": [
+          ".cpp",
+          ".h"
+        ]
+      },
+      {
+        "id": "c",
+        "extensions": [
+          ".c",
+          ".h"
+        ]
+      },
+      {
+        "id": "json",
+        "extensions": [
+          ".json"
+        ]
+      },
+      {
+        "id": "yaml",
+        "extensions": [
+          ".yaml",
+          ".yml"
+        ]
+      },
+      {
+        "id": "javascript",
+        "extensions": [
+          ".js"
+        ]
+      },
+      {
+        "id": "typescript",
+        "extensions": [
+          ".ts"
+        ]
+      },
+      {
+        "id": "sql",
+        "extensions": [
+          ".sql"
+        ]
+      },
+      {
+        "id": "markdown",
+        "extensions": [
+          ".md"
+        ]
+      },
+      {
+        "id": "python",
+        "extensions": [
+          ".py",
+          ".rpy",
+          ".pyw",
+          ".cpy",
+          ".SConstruct",
+          ".Sconstruct",
+          ".sconstruct",
+          ".SConscript",
+          ".gyp",
+          ".gypi"
+        ]
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile:prod",


### PR DESCRIPTION
Using gradle configuration cache can improve the time for formatting on
project which has log of dependencies and configurations.